### PR TITLE
Widen JWT dependency to allow v3

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     pusher-push-notifications (2.0.2)
-      jwt (~> 2.1, >= 2.1.0)
+      jwt (>= 2.1, < 4)
       rest-client (~> 2.0, >= 2.0.2)
 
 GEM
@@ -11,9 +11,11 @@ GEM
     addressable (2.9.0)
       public_suffix (>= 2.0.2, < 8.0)
     ast (2.4.2)
+    base64 (0.3.0)
     byebug (11.1.3)
-    codecov (0.5.1)
-      simplecov (>= 0.15, < 0.22)
+    codecov (0.2.12)
+      json
+      simplecov
     coderay (1.1.3)
     coveralls (0.8.23)
       json (>= 1.8, < 3)
@@ -33,7 +35,8 @@ GEM
     http-cookie (1.0.3)
       domain_name (~> 0.5)
     json (2.5.1)
-    jwt (2.2.2)
+    jwt (3.2.0)
+      base64
     method_source (1.0.0)
     mime-types (3.3.1)
       mime-types-data (~> 3.2015)
@@ -123,4 +126,4 @@ DEPENDENCIES
   webmock (~> 3.0, >= 3.0.1)
 
 BUNDLED WITH
-   2.2.13
+   2.7.2

--- a/pusher-push-notifications.gemspec
+++ b/pusher-push-notifications.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'jwt', '~> 2.1', '>= 2.1.0'
+  spec.add_dependency 'jwt', '>= 2.1', '< 4'
   spec.add_dependency 'rest-client', '~> 2.0', '>= 2.0.2'
 
   spec.add_development_dependency 'bundler', '~> 2.2'


### PR DESCRIPTION
## Summary

- Widens the `jwt` dependency constraint from `~> 2.1, >= 2.1.0` to `>= 2.1, < 4`
- Updates `Gemfile.lock` to resolve to jwt 3.2.0

The previous constraint caused two issues:

- **Ruby 3.4 compatibility** — jwt 2.x requires `base64` without declaring it as a dependency. Ruby 3.4 removed `base64` from its default gems, causing a `LoadError` at runtime. jwt 3.x declares it explicitly.
- **Downstream conflicts** — the narrow `~> 2.1` range blocked consumers from upgrading their own jwt dependency. The widened range allows v2 or v3 to resolve without conflict.

The gem's only usage is `JWT.encode payload, secret_key, 'HS256'`, which is unchanged between v2 and v3.