### PR TITLE
Bump version to 2.0.3 for release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2.0.3
+
+* [FIXED] Ruby 3.4 compatibility
+* [CHANGED] Widen JWT dependency constraint from ~> 2.1 to >= 2.1, < 4 to support jwt v3
+* [REMOVED] Support for Ruby below 3.3
+
 ## 2.0.2
 
 * [FIXED] Multiple Beams instances no longer use last configuration.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    pusher-push-notifications (2.0.2)
+    pusher-push-notifications (2.0.3)
       jwt (>= 2.1, < 4)
       rest-client (~> 2.0, >= 2.0.2)
 

--- a/lib/pusher/push_notifications/version.rb
+++ b/lib/pusher/push_notifications/version.rb
@@ -2,6 +2,6 @@
 
 module Pusher
   module PushNotifications
-    VERSION = '2.0.2'
+    VERSION = '2.0.3'
   end
 end


### PR DESCRIPTION
## 2.0.3

* [FIXED] Ruby 3.4 compatibility
* [CHANGED] Widen JWT dependency constraint from ~> 2.1 to >= 2.1, < 4 to support jwt v3
* [REMOVED] Support for Ruby below 3.3